### PR TITLE
fix: don't override NAPI Finalize method

### DIFF
--- a/src/streaming_parser.cc
+++ b/src/streaming_parser.cc
@@ -61,7 +61,7 @@ Napi::Object StreamingParser::Init(Napi::Env env, Napi::Object exports) {
   Napi::Function func = DefineClass(env, "StreamingParser", {
     InstanceMethod("isFinished", &StreamingParser::IsFinished),
     InstanceMethod("write", &StreamingParser::Write),
-    InstanceMethod("finalize", &StreamingParser::Finalize),
+    InstanceMethod("finalize", &StreamingParser::FinalizeMethod),
     InstanceMethod("destroy", &StreamingParser::Destroy)
   });
 
@@ -106,7 +106,7 @@ Napi::Value StreamingParser::Write(const Napi::CallbackInfo& info) {
   return info.Env().Undefined();
 }
 
-Napi::Value StreamingParser::Finalize(const Napi::CallbackInfo& info) {
+Napi::Value StreamingParser::FinalizeMethod(const Napi::CallbackInfo& info) {
   this->finished = true;
   Napi::Function callback = info[0].As<Napi::Function>();
 

--- a/src/streaming_parser.h
+++ b/src/streaming_parser.h
@@ -8,7 +8,7 @@ class StreamingParser : public Napi::ObjectWrap<StreamingParser> {
   ~StreamingParser();
   Napi::Value IsFinished(const Napi::CallbackInfo& info);
   Napi::Value Write(const Napi::CallbackInfo& info);
-  Napi::Value Finalize(const Napi::CallbackInfo& info);
+  Napi::Value FinalizeMethod(const Napi::CallbackInfo& info);
   Napi::Value Destroy(const Napi::CallbackInfo& info);
 
  private:


### PR DESCRIPTION
Just noticed when installing `electron-markdown`.